### PR TITLE
Replace O3-mini with O3 as default reasoning model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ npx -y ultra-mcp chat
 node dist/cli.js chat
 
 # Specify model and provider
-npx -y ultra-mcp chat -m o3-mini -p openai
+npx -y ultra-mcp chat -m o3 -p openai
 npx -y ultra-mcp chat -m grok-4 -p grok
 ```
 
@@ -236,7 +236,7 @@ Ultra MCP exposes the following AI-powered tools through the Model Context Proto
 Use advanced AI models for deep reasoning and complex problem-solving.
 
 - **Default Models**:
-  - OpenAI/Azure: O3-mini (optimized for reasoning)
+  - OpenAI/Azure: O3 (optimized for reasoning)
   - Gemini: Gemini 2.5 Pro with Google Search enabled
 - **Parameters**:
   - `prompt`: The complex question or problem (required)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Check installation health and test API connections.
 npx -y ultra-mcp chat
 
 # Specify model and provider
-npx -y ultra-mcp chat -m o3-mini -p openai
+npx -y ultra-mcp chat -m o3 -p openai
 npx -y ultra-mcp chat -m grok-4 -p grok
 ```
 
@@ -239,7 +239,7 @@ Ultra MCP provides powerful AI tools accessible through Claude Code and Cursor:
 
 Leverage advanced AI models for complex problem-solving and analysis.
 
-- **Default**: O3-mini for OpenAI/Azure, Gemini 2.5 Pro with Google Search, Grok-4 for xAI
+- **Default**: O3 for OpenAI/Azure, Gemini 2.5 Pro with Google Search, Grok-4 for xAI
 - **Use Cases**: Complex algorithms, architectural decisions, deep analysis
 
 ### 🔍 Investigate (`investigate`)

--- a/src/__tests__/workflow-tools.test.ts
+++ b/src/__tests__/workflow-tools.test.ts
@@ -73,7 +73,7 @@ describe('Workflow Tools - Zen MCP Integration', () => {
         models: [
           { model: 'gemini-pro', stance: 'for' as const, provider: 'gemini' as const },
           { model: 'gpt-4', stance: 'against' as const, provider: 'openai' as const },
-          { model: 'o3-mini', stance: 'neutral' as const, provider: 'azure' as const }
+          { model: 'o3', stance: 'neutral' as const, provider: 'azure' as const }
         ]
       };
 

--- a/src/api/trpc/routers/models.ts
+++ b/src/api/trpc/routers/models.ts
@@ -18,7 +18,7 @@ export const modelsRouter = router({
         { id: 'gpt-4o-mini', name: 'GPT-4o Mini', provider: 'openai', description: 'Faster, cheaper' },
         { id: 'o1', name: 'O1', provider: 'openai', description: 'Advanced reasoning' },
         { id: 'o1-mini', name: 'O1 Mini', provider: 'openai', description: 'Efficient reasoning' },
-        { id: 'o3-mini', name: 'O3 Mini', provider: 'openai', description: 'Latest reasoning model' },
+        { id: 'o3', name: 'O3', provider: 'openai', description: 'Latest reasoning model' },
       );
     }
     
@@ -36,7 +36,7 @@ export const modelsRouter = router({
       models.push(
         { id: 'gpt-4o', name: 'GPT-4o (Azure)', provider: 'azure', description: 'Enterprise grade' },
         { id: 'gpt-4o-mini', name: 'GPT-4o Mini (Azure)', provider: 'azure', description: 'Cost effective' },
-        { id: 'o3-mini', name: 'O3 Mini (Azure)', provider: 'azure', description: 'Latest reasoning' },
+        { id: 'o3', name: 'O3 (Azure)', provider: 'azure', description: 'Latest reasoning' },
       );
     }
     
@@ -48,7 +48,7 @@ export const modelsRouter = router({
     return {
       defaultProvider: 'azure',
       modelPriorities: [
-        { model: 'o3-mini', priority: 1 },
+        { model: 'o3', priority: 1 },
         { model: 'gpt-4o', priority: 2 },
         { model: 'gemini-2.0-flash-exp', priority: 3 },
       ],

--- a/src/handlers/ai-tools.ts
+++ b/src/handlers/ai-tools.ts
@@ -77,7 +77,7 @@ const ChallengeSchema = z.object({
 const ConsensusSchema = z.object({
   proposal: z.string().describe("The proposal, idea, or decision to analyze from multiple perspectives"),
   models: z.array(z.object({
-    model: z.string().describe("Model name to consult (e.g., 'gemini-pro', 'gpt-4', 'o3-mini')"),
+    model: z.string().describe("Model name to consult (e.g., 'gemini-pro', 'gpt-4', 'o3')"),
     stance: z.enum(["for", "against", "neutral"]).default("neutral").describe("Perspective stance for this model"),
     provider: z.enum(["openai", "gemini", "azure", "grok"]).optional().describe("AI provider for this model")
   })).min(1).describe("List of models to consult with their stances"),
@@ -1676,7 +1676,7 @@ Explain these options clearly and wait for the user to specify which mode to use
                 properties: {
                   model: {
                     type: "string",
-                    description: "Model name to consult (e.g., 'gemini-pro', 'gpt-4', 'o3-mini')",
+                    description: "Model name to consult (e.g., 'gemini-pro', 'gpt-4', 'o3')",
                   },
                   stance: {
                     type: "string",


### PR DESCRIPTION
This PR addresses issue #5 by replacing O3-mini with O3 as the default reasoning model throughout the codebase.

## Changes Made:
- Updated documentation in CLAUDE.md and README.md to reflect O3 as default
- Updated TRPC models router to use O3 instead of O3-mini
- Updated test files and CLI examples to use O3
- Updated description examples in tool schemas
- Provider implementations already use O3 as default model

Resolves issue where O3-mini was considered too weak for deep reasoning tasks.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references in documentation to use "o3" as the default OpenAI/Azure model instead of "o3-mini" in CLI examples and tool descriptions.

* **Tests**
  * Changed test parameters to use "o3" instead of "o3-mini" for model-related test cases.

* **Refactor**
  * Updated model lists, priorities, and descriptions throughout the app to consistently reference "o3" as the default model. 
  * Adjusted example model names in tool schemas and descriptions to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->